### PR TITLE
Potential fix for code scanning alert no. 2: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -405,6 +405,25 @@ func createTarGz(src string, writer io.Writer) error {
 	})
 }
 
+func safeJoin(baseDir, entryName string) (string, error) {
+	if filepath.IsAbs(entryName) {
+		return "", fmt.Errorf("invalid archive entry path: absolute path not allowed: %q", entryName)
+	}
+
+	baseClean := filepath.Clean(baseDir)
+	target := filepath.Join(baseClean, entryName)
+
+	rel, err := filepath.Rel(baseClean, target)
+	if err != nil {
+		return "", fmt.Errorf("failed to validate archive entry path %q: %v", entryName, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid archive entry path: traversal detected: %q", entryName)
+	}
+
+	return target, nil
+}
+
 func extractTarGz(reader io.Reader, dst string) error {
 	gzReader, err := gzip.NewReader(reader)
 	if err != nil {
@@ -428,8 +447,11 @@ func extractTarGz(reader io.Reader, dst string) error {
 			return fmt.Errorf("failed to read tar header: %v", err)
 		}
 
-		// Get the target path
-		target := filepath.Join(dst, header.Name)
+		// Get and validate the target path to prevent path traversal
+		target, err := safeJoin(dst, header.Name)
+		if err != nil {
+			return err
+		}
 
 		switch header.Typeflag {
 		case tar.TypeDir:


### PR DESCRIPTION
Potential fix for [https://github.com/rikribbers/bidprentjes-go/security/code-scanning/2](https://github.com/rikribbers/bidprentjes-go/security/code-scanning/2)

To fix this safely without changing intended behavior, validate each tar entry path before using it:

1. Clean and normalize destination root with `filepath.Clean`.
2. For each header, compute `target := filepath.Join(dst, header.Name)`.
3. Resolve both to absolute/cleaned paths and ensure `target` is inside `dst` using `filepath.Rel` (or equivalent prefix-safe check).
4. Reject entries that escape (`rel == ".."` or starts with `".."+string(os.PathSeparator)`), or absolute names.
5. Only then proceed with directory/file creation.

Best single fix in `store/store.go` is to add a helper (e.g., `safeJoin`) and use it in `extractTarGz` in place of direct `filepath.Join(dst, header.Name)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
