### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,5 +1,8 @@
 name: Build and Push Docker Image
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/rikribbers/bidprentjes-go/security/code-scanning/1](https://github.com/rikribbers/bidprentjes-go/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/docker-build.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves existing behavior (checkout/build/tag metadata generation) while ensuring the token cannot silently gain broader access from repo/org defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
