### PR TITLE
Potential fix for code scanning alert no. 2: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -406,22 +406,30 @@ func createTarGz(src string, writer io.Writer) error {
 }
 
 func safeJoin(baseDir, entryName string) (string, error) {
-	if filepath.IsAbs(entryName) {
+	cleanEntry := filepath.Clean(entryName)
+	if filepath.IsAbs(cleanEntry) {
 		return "", fmt.Errorf("invalid archive entry path: absolute path not allowed: %q", entryName)
 	}
-
-	baseClean := filepath.Clean(baseDir)
-	target := filepath.Join(baseClean, entryName)
-
-	rel, err := filepath.Rel(baseClean, target)
-	if err != nil {
-		return "", fmt.Errorf("failed to validate archive entry path %q: %v", entryName, err)
-	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+	if cleanEntry == ".." || strings.HasPrefix(cleanEntry, ".."+string(os.PathSeparator)) {
 		return "", fmt.Errorf("invalid archive entry path: traversal detected: %q", entryName)
 	}
 
-	return target, nil
+	baseAbs, err := filepath.Abs(filepath.Clean(baseDir))
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve base directory %q: %v", baseDir, err)
+	}
+
+	targetAbs, err := filepath.Abs(filepath.Join(baseAbs, cleanEntry))
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve archive entry path %q: %v", entryName, err)
+	}
+
+	basePrefix := baseAbs + string(os.PathSeparator)
+	if targetAbs != baseAbs && !strings.HasPrefix(targetAbs, basePrefix) {
+		return "", fmt.Errorf("invalid archive entry path: traversal detected: %q", entryName)
+	}
+
+	return targetAbs, nil
 }
 
 func extractTarGz(reader io.Reader, dst string) error {


### PR DESCRIPTION
Potential fix for [https://github.com/rikribbers/bidprentjes-go/security/code-scanning/2](https://github.com/rikribbers/bidprentjes-go/security/code-scanning/2)

To fix this safely and without changing intended functionality, strengthen path validation in `safeJoin` so any tar entry path is normalized and then verified to stay strictly under the destination directory.

Best approach in this file (`store/store.go`):
- In `safeJoin`, clean `entryName` first (`filepath.Clean`).
- Reject absolute paths and entries that resolve to `".."` or begin with `"../"`.
- Join using the cleaned entry.
- Canonicalize both `baseDir` and the joined target using `filepath.Abs`.
- Enforce that the absolute target is either exactly the base directory or has the base directory as a path prefix (`base + separator`).

This addresses all three alert variants at once because every filesystem operation uses `target` returned from `safeJoin`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
